### PR TITLE
Potential fix for code scanning alert no. 1: Flask app is run in debug mode

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -16,4 +16,5 @@ init_db(app)
 app.register_blueprint(games_bp)
 
 if __name__ == '__main__':
-    app.run(debug=True, port=5100) # Port 5100 to avoid macOS conflicts
+    debug_mode = os.environ.get('FLASK_DEBUG', '0') == '1'
+    app.run(debug=debug_mode, port=5100) # Port 5100 to avoid macOS conflicts


### PR DESCRIPTION
Potential fix for [https://github.com/CarolynChenAS/agents-in-sdlc-carolyn/security/code-scanning/1](https://github.com/CarolynChenAS/agents-in-sdlc-carolyn/security/code-scanning/1)

**General Fix:**  
Do not use `debug=True` unconditionally in the Flask `app.run()` call. Only enable debug mode during development, typically controlled via an environment variable or configuration setting.

**Best Way to Fix:**  
Edit the `if __name__ == '__main__':` block to set the debug parameter conditionally, controlled by an environment variable (e.g., `FLASK_DEBUG`). By default, debug mode should be off in production, and only enabled explicitly for development. This preserves developer convenience while providing safety.

**Specific Changes:**
- Import `os` is already present, so use `os.environ.get('FLASK_DEBUG', '0') == '1'` to control debug mode.
- Replace the `app.run(debug=True, port=5100)` line with code that assigns a `debug` value based on the environment variable, then passes that value to `app.run()`.
- Do not change any functionality except the `debug` flag handling.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
